### PR TITLE
Fix uninitialized variable

### DIFF
--- a/door_lock_control/door_lock_control.ino
+++ b/door_lock_control/door_lock_control.ino
@@ -18,8 +18,10 @@ void setup() {
   Serial.begin(SERIAL_BPS);
   myservo.attach(SERVOMOTOR_PIN);
   myservo.write(OPEN_POSITION);
+  buttonState = 1;
   delay(WAIT_LONG);
   myservo.write(CLOSE_POSITION);
+  buttonState = 0;
   delay(WAIT_SHORT);
   
   pinMode(PUSH_BUTTON, INPUT_PULLUP);


### PR DESCRIPTION
The variable `int buttonState` was never initialised for the first loop iteration. C doesn't auto initialise variables, so the variables just take value the allocated memory slot contained.

Good that you used good practices of explicitly checking for _true=1_ and _false=0_ instead of _0=false_ and _non-zero=true_. That reduced the chances of failure to only 1 of ~32,767.

These changes should make the code safer.